### PR TITLE
Solving compilation issue on OS X 10.11.4

### DIFF
--- a/src/ministat.c
+++ b/src/ministat.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/queue.h>
+#include <err.h>
 
 #define NSTUDENT 100
 #define NCONF 6


### PR DESCRIPTION
There was a missing include (err.h) for compiling ministat.c on OS X 10.11

ministat.c:483:3: warning: implicit declaration of function 'err' is invalid in C99 [-Wimplicit-function-declaration]
                err(1, "Cannot open %s", n);
